### PR TITLE
Camelcase for Javascript

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
                     <h2>What is GeoJSON?</h2>
                     <ul>
                     <li>Structured information about geospatially-bounded things (aka "features") and their properties</li>
-                    <li>Using Javascript Object Notation</li>
+                    <li>Using JavaScript Object Notation</li>
                     </ul>
                 </section>
 
@@ -140,7 +140,7 @@
                     <h2>Applications</h2>
                     <p>Almost any kind of geospatial JSON data interchange</p>
                     <ul>
-                    <li>HTTP CRUD and Javascript APIs</li>
+                    <li>HTTP CRUD and JavaScript APIs</li>
                     <li>Spatial database queries</li>
                     <li>Alerting and geo-fencing protocols</li>
                     <li>Defining coverage of networked mobile apps</li>


### PR DESCRIPTION
This makes the spelling of JavaScript consistent with http://tools.ietf.org/html/draft-butler-geojson-05, https://tools.ietf.org/html/rfc7159, https://www.ietf.org/rfc/rfc4627.txt, etc.
